### PR TITLE
Only run CI against MRI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+cache: bundler
+sudo: false
 language: ruby
 notifications:
   email: false
 rvm:
-- 2.0.0
-- jruby-19mode
+- 2.2.0


### PR DESCRIPTION
> IIRC, our minimum Ruby support requirement is:
>  the latest version of MRI.
>
> It mostly comes down to "what does thoughtbot use?",
>  and we use whatever Heroku uses.

> - mike-burns [18:14]