### PR TITLE
Release `0.3.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+0.3.1
+-----
+
 * BREAKING CHANGE: Rename module to `JsonMatchers`. This resolves clashing with
   gems like `oj` / `oj_mimic_json` that take control of the standard library's
   `json` module. As a result, the file to require is now `json_matchers`,

--- a/lib/json-matchers.rb
+++ b/lib/json-matchers.rb
@@ -1,8 +1,8 @@
 warn <<-WARNING
-DEPRECATED: requiring the library via `require "json-matchers"` is deprecated.
+DEPRECATED: The `json-matchers` gem has been deprecated.
 
-To include the library, please add `require "json_matchers/rspec"` to your
-`spec/spec_helper.rb`.
+Please replace change your Gemfile's reference from `json-matchers` to
+`json_matchers`.
 WARNING
 
 require "json_matchers"

--- a/lib/json_matchers/version.rb
+++ b/lib/json_matchers/version.rb
@@ -1,3 +1,3 @@
 module JsonMatchers
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Version `0.3.1` will be the last gem published to `json-matchers`.

In version `0.4.0`, the gem will transition to `json_matchers`.